### PR TITLE
need to enforce a dot region for base format

### DIFF
--- a/lib/src/utils/utilities.dart
+++ b/lib/src/utils/utilities.dart
@@ -58,7 +58,7 @@ class _Utilities {
 
   /// Returns formatted number
   String get baseFormat => NumberFormat.currency(
-          symbol: '', decimalDigits: this.settings.fractionDigits)
+          symbol: '', decimalDigits: this.settings.fractionDigits, locale: 'en_US')
       .format(amount);
 
   /// Returns formatted number with refined separator chars


### PR DESCRIPTION
When using the nl_NL locale in my app which uses a **comma decimalSeparator** this library crashes.
The issue is resolved by enforcing a **dot decimalSeparator** region like en_US for processing.
Crash stack trace:
```
flutter: _LocalizationsScope-[GlobalKey#c52f0]]):
flutter: 0, 42
flutter:
flutter: When the exception was thrown, this was the stack:
flutter: #0      num.parse (dart:core/num.dart:474:26)
flutter: #1      FlutterMoneyFormatter._compactNonSymbol (package:flutter_money_formatter/src/flutter_money_formatter_base.dart:170:21)
flutter: #2      FlutterMoneyFormatter._getOutput (package:flutter_money_formatter/src/flutter_money_formatter_base.dart:85:27)
flutter: #3      new FlutterMoneyFormatter (package:flutter_money_formatter/src/flutter_money_formatter_base.dart:58:14)
flutter: #4      CalculateVatModel.priceVat (package:_____app/models/CalculateVatModel.dart:109:12)
flutter: #5      CalculateVatScreenState._renderCalculatorDisplay (package:_____app/screens/calculate_vat_screen.dart:143:34)
flutter: #6      CalculateVatScreenState._renderBody.<anonymous closure> (package:_____app/screens/calculate_vat_screen.dart:103:23)
flutter: #7      ScopedModelDescendant.build (package:scoped_model/scoped_model.dart:261:12)
flutter: #8      StatelessElement.build (package:flutter/src/widgets/framework.dart:3974:28)
flutter: #9      ComponentElement.performRebuild (package:flutter/src/widgets/framework.dart:3924:15)
flutter: #10     Element.rebuild (package:flutter/src/widgets/framework.dart:3721:5)
flutter: #11     BuildOwner.buildScope (package:flutter/src/widgets/framework.dart:2340:33)
flutter: #12     _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding&PaintingBinding&SemanticsBinding&RendererBinding&WidgetsBinding.drawFrame (package:flutter/src/widgets/binding.dart:700:20)
flutter: #13     _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding&PaintingBinding&SemanticsBinding&RendererBinding._handlePersistentFrameCallback (package:flutter/src/rendering/binding.dart:285:5)
flutter: #14     _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding._invokeFrameCallback (package:flutter/src/scheduler/binding.dart:1016:15)
flutter: #15     _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding.handleDrawFrame (package:flutter/src/scheduler/binding.dart:958:9)
flutter: #16     _WidgetsFlutterBinding&BindingBase&GestureBinding&ServicesBinding&SchedulerBinding._handleDrawFrame (package:flutter/src/scheduler/binding.dart:874:5)
flutter: #20     _invoke (dart:ui/hooks.dart:236:10)
flutter: #21     _drawFrame (dart:ui/hooks.dart:194:3)
flutter: (elided 3 frames from package dart:async)
flutter: ════════════════════════════════════════════════════════════════════════════════════════════════════
```